### PR TITLE
Fix missing partition scheme setting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The `lv_conf.h` file configures the LVGL graphics library:
 2. **ESP32 Firmware**
    - Open `bongo_cat.ino` in Arduino IDE
    - Ensure libraries are installed
+   - Set Partition Scheme to `Huge APP (3MB No OTA/1MB SPIFFS)` under `Tools`
    - Upload to your ESP32
 
 3. **Desktop Application**


### PR DESCRIPTION
Add the missing mention of setting the partition scheme in Arduino IDE to "Huge APP (3MB No OTA/1MB SPIFFS)"

Fixes #1